### PR TITLE
fix travis cli & update repo's path references

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: node_js
 node_js:
-  - iojs
+  - "iojs"
   - "0.12"
+
+cache:
+  directories:
+    - node_modules
+
 script: "npm test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,5 @@ cache:
   directories:
     - node_modules
 
+before_script: "npm run build"
 script: "npm test"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 
 <p align="center">
-  <a href="http://github.com/flyjs/fly-util">
+  <a href="http://github.com/bucaran/fly-util">
     <img width=180px  src="https://cloud.githubusercontent.com/assets/8317250/8733685/0be81080-2c40-11e5-98d2-c634f076ccd7.png">
   </a>
 </p>
@@ -145,13 +145,13 @@ Bind to node's require based in the file extension of your Flyfile.
 :heart:
 
 [author]: http://about.bucaran.me
-[contributors]: https://github.com/flyjs/fly-util/graphs/contributors
-[fly]: https://www.github.com/flyjs/fly
-[fly-util]: https://www.github.com/flyjs/fly-util
+[contributors]: https://github.com/bucaran/fly-util/graphs/contributors
+[fly]: https://www.github.com/bucaran/fly
+[fly-util]: https://www.github.com/bucaran/fly-util
 [fly-badge]: https://img.shields.io/badge/fly-JS-05B3E1.svg?style=flat-square
 [mit-badge]: https://img.shields.io/badge/license-MIT-444444.svg?style=flat-square
 [npm-pkg-link]: https://www.npmjs.org/package/fly-util
 [npm-ver-link]: https://img.shields.io/npm/v/fly-util.svg?style=flat-square
 [dl-badge]: http://img.shields.io/npm/dm/fly-util.svg?style=flat-square
-[travis-logo]: http://img.shields.io/travis/flyjs/fly-util.svg?style=flat-square
-[travis]: https://travis-ci.org/flyjs/fly-util
+[travis-logo]: http://img.shields.io/travis/bucaran/fly-util.svg?style=flat-square
+[travis]: https://travis-ci.org/bucaran/fly-util

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/flyjs/fly-util.git"
+    "url": "git+https://github.com/bucaran/fly-util.git"
   },
   "keywords": [
     "fly",
@@ -48,11 +48,11 @@
   "author": "Jorge Bucaran",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/flyjs/fly-util/issues"
+    "url": "https://github.com/bucaran/fly-util/issues"
   },
   "engines": {
     "iojs": ">= 1.0.0",
     "node": ">= 0.12.0"
   },
-  "homepage": "https://github.com/flyjs/fly-util"
+  "homepage": "https://github.com/bucaran/fly-util"
 }

--- a/package.json
+++ b/package.json
@@ -29,11 +29,10 @@
     "tape": "^4.0.0"
   },
   "scripts": {
-    "setup": "npm i && npm run test",
-    "test": "npm run build && npm run lint && npm run harmony-test | tspec",
+    "setup": "npm i && npm run build && npm run test",
+    "test": "npm run lint && babel-node ./node_modules/tape/bin/tape test/*.js | tspec",
     "build": "babel --optional runtime src/ -d ./dist",
     "lint": "eslint src/",
-    "harmony-test": "node --harmony --harmony_arrow_functions ./node_modules/tape/bin/tape test/*.js",
     "deploy": "npm run test && git push origin master && npm publish",
     "prepublish": "npm run build"
   },


### PR DESCRIPTION
All Readme links were still pointing back to `flyjs/fly-util`, which doesn't exist & redirects to `bucaran/fly`. 

This prevented TravisCLI from running -- as noted by the "Build: Invalid" badge.
